### PR TITLE
set SITEURL as github repository variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Build site
         run: pelican content -s publishconf.py
+        env:
+          SITEURL: ${{ vars.SITEURL }}
 
       - name: Upload artifact for GitHub Pages
         uses: actions/upload-pages-artifact@v3

--- a/publishconf.py
+++ b/publishconf.py
@@ -8,7 +8,7 @@ sys.path.append(os.curdir)
 from pelicanconf import *
 
 # If your site is available via HTTPS, make sure SITEURL begins with https://
-SITEURL = "https://flisolcuenca.github.io"
+SITEURL = os.environ.get("SITEURL", "https://flisol-cuenca.github.io")
 RELATIVE_URLS = False
 
 FEED_ALL_ATOM = "feeds/all.atom.xml"


### PR DESCRIPTION
# What
Solve issue #15 
The SITEURL variable is declared as Github repository variable to use it when deploy the website.
