### PR TITLE
Fix typos in event agenda

### DIFF
--- a/theme/templates/sections/agenda.html
+++ b/theme/templates/sections/agenda.html
@@ -88,16 +88,16 @@
                 "topic": "IoT · Hardware",
                 "sessions": [
                     {"kind": "talk", "start": "11:00", "end": "11:30",
-                     "speaker": "José Loiza",
+                     "speaker": "José Laica",
                      "title": "Ecosistema libre para el desarrollo de proyectos y productos electrónicos"},
                     {"kind": "lightning", "start": "11:37", "end": "11:47",
-                     "speaker": "Jonathan Parrago",
+                     "speaker": "Jonathan Parraga",
                      "title": "Del código al objeto físico (impresión 3D)"},
                     {"kind": "lightning", "start": "11:55", "end": "12:05",
                      "speaker": "Sebastián Caiza y Mao Jaramillo",
                      "title": "Node-RED: el cerebro visual de la automatización, el IoT y los sistemas inteligentes"},
                     {"kind": "lightning", "start": "12:12", "end": "12:22",
-                     "speaker": "Anthony Bagboy",
+                     "speaker": "Anthony Sagbay",
                      "title": "Dispositivos abiertos, hogares más seguros"},
                     {"kind": "panel", "start": "12:30", "end": "13:00",
                      "title": "Panel · Conversación con expositores"}
@@ -122,7 +122,7 @@
                     {"kind": "panel", "start": "15:30", "end": "16:00",
                      "title": "Panel · Conversación con expositores"},
                     {"kind": "individual", "start": "16:00", "end": "16:30",
-                     "speaker": "Anthony Grijalva y Xavier Liauca",
+                     "speaker": "Anthony Grijalva y Xavier Llauca",
                      "title": "DevSecOps y observabilidad de extremo a extremo con software libre"}
                 ]
             }


### PR DESCRIPTION
# What
fix typos in speaker names [event agenda]